### PR TITLE
Ignore in fastboot and document the bug for `fingerprintAssetMap: true` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ const app = new EmberAddon(defaults, {
   fingerprint: {
     enabled: true, // If false, this addon is disabled also.
     generateAssetMap: true, // Required.
-    fingerprintAssetMap: true // Recommended to prevent caching issues.
+    
+    // Recommended to prevent caching issues, although currently for it work you will need to use a fork of 
+    // "broccoli-asset-rev": "https://github.com/joankaradimov/broccoli-asset-rev#fix-duplicate-generation"
+    fingerprintAssetMap: true 
   },
 
   'ember-fetch': {

--- a/addon/-private/asset-map-path.js
+++ b/addon/-private/asset-map-path.js
@@ -3,9 +3,11 @@
  * into the `<head>` by `index.js`.
  */
 export default (() => {
-  const link = document.getElementById(
-    'ember-cli-resolve-asset-asset-map-path'
-  );
-  if (link) return link.getAttribute('href');
+  if (typeof FastBoot === 'undefined') {
+    const link = document.getElementById(
+      'ember-cli-resolve-asset-asset-map-path'
+    );
+    if (link) return link.getAttribute('href');
+  }
   return null;
 })();


### PR DESCRIPTION
Hello 👋🏼   `ember-svg-jar`'s hbs strategy just got merged https://github.com/ivanvotti/ember-svg-jar/pull/186 and it depends on this addon to resolve the assets! while trying to document how to use the strategy for the readme I found two things:

1. `This` addon doesn't support fastboot right now, so for now at least disable. Not sure if it _should_ though, with the prefetch stuff, maybe if we expose the `LINK_ID` config to the load func, and use the `shoebox` approach or something could be interesting, maybe it could be opt-in.
2. Currently using `fingerprintAssetMap: true` has a terrible bug https://github.com/ember-cli/broccoli-asset-rev/issues/122, so add documentation to the README

What do you think about fastboot support? for a follow-up PR, would it make sense that it could be resolved via https://github.com/ember-fastboot/ember-cli-fastboot#the-shoebox?